### PR TITLE
Fixes for newer SDK/tools

### DIFF
--- a/Audio.hpp
+++ b/Audio.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "32blit.hpp"
 #include "audio/mp3-stream.hpp"
 
 namespace AudioHandler {

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -590,7 +590,9 @@ GameMetadata metadata;
 #pragma pack(push,1)
 struct TMX16 {
     char head[4];
-    uint8_t empty_tile;
+    uint16_t header_length;
+    uint16_t flags;
+    uint16_t empty_tile;
     uint16_t width;
     uint16_t height;
     uint16_t layers;

--- a/SuperSquareBros.hpp
+++ b/SuperSquareBros.hpp
@@ -1,4 +1,8 @@
-#include "32blit.hpp"
+#include "engine/api.hpp"
+#include "engine/engine.hpp"
+#include "engine/input.hpp"
+#include "engine/save.hpp"
 #include "engine/version.hpp"
+#include "graphics/sprite.hpp"
 
 #include "Audio.hpp"

--- a/assets.yml
+++ b/assets.yml
@@ -104,17 +104,17 @@ assets.cpp:
   assets/music_splash.mp3:
     name: asset_music_splash
 
-  assets/music_menu.mp3:
-    name: asset_music_menu
+#  assets/music_menu.mp3:
+#    name: asset_music_menu
     
-  assets/music_grass.mp3:
-    name: asset_music_grass
+#  assets/music_grass.mp3:
+#    name: asset_music_grass
     
-  assets/music_snow.mp3:
-    name: asset_music_snow
+#  assets/music_snow.mp3:
+#    name: asset_music_snow
     
-  assets/music_end.mp3:
-    name: asset_music_end
+#  assets/music_end.mp3:
+#    name: asset_music_end
     
-  assets/music_boss.mp3:
-    name: asset_music_boss
+#  assets/music_boss.mp3:
+#    name: asset_music_boss


### PR DESCRIPTION
A few fixes I had to do when we were experimenting with running stuff on the pico.

- Newer tools error out on missing files
- Map format changed in v0.1.13
- v0.1.14 causes some naming conflicts as `32blit.hpp` now includes _everything_ (`blit::Particle` vs `Particle`)