### PR TITLE
Patch gadgetoid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,15 @@
 # Basic parameters; check that these match your project / environment
 cmake_minimum_required(VERSION 3.8)
 
+# has to be before project
+if(PICO_SDK_PATH)
+    include(${32BLIT_DIR}/32blit-pico/pico_sdk_import.cmake)
+    include(${32BLIT_DIR}/32blit-pico/pico_extras_import.cmake)
+endif()
+
+
 project(Super-Square-Bros)
-set(PROJECT_SOURCE SuperSquareBros.cpp Audio.cpp)
+set(PROJECT_SOURCE SuperSquareBros.cpp)
 set(PROJECT_DISTRIBS LICENSE README.md)
 
 # Build configuration; approach this with caution!
@@ -13,9 +20,16 @@ else()
 endif()
 find_package (32BLIT CONFIG REQUIRED PATHS ../32blit-sdk)
 
+if(PICO_SDK_PATH)
+set(PROJECT_SOURCE ${PROJECT_SOURCE} PicoAudio.cpp)
+else()
+set(PROJECT_SOURCE ${PROJECT_SOURCE} Audio.cpp)
+endif()
+
 blit_executable (${PROJECT_NAME} ${PROJECT_SOURCE})
 blit_assets_yaml (${PROJECT_NAME} assets.yml)
 blit_metadata (${PROJECT_NAME} metadata.yml)
+target_compile_definitions(${PROJECT_NAME} PRIVATE ALLOW_HIRES=0)
 add_custom_target (flash DEPENDS ${PROJECT_NAME}.flash)
 
 # setup release packages

--- a/PicoAudio.cpp
+++ b/PicoAudio.cpp
@@ -1,0 +1,40 @@
+#include "PicoAudio.hpp"
+
+// Todo: rework to pick a free channel rather than always using same one.
+
+namespace AudioHandler {
+	AudioHandler::AudioHandler() { }
+
+	void AudioHandler::set_volume(uint32_t volume) {
+		(void)volume;
+	}
+
+	void AudioHandler::set_volume(uint8_t channel, uint32_t volume) {
+		(void)channel;
+		(void)volume;
+	}
+
+	void AudioHandler::load(uint8_t channel, const uint8_t mp3_data[], const uint32_t mp3_size) {
+		(void)channel;
+		(void *)mp3_data;
+		(void)mp3_size;
+	}
+
+	void AudioHandler::load(uint8_t target_channel, uint8_t source_channel) {
+		(void)target_channel;
+		(void)source_channel;
+	}
+
+	void AudioHandler::play(uint8_t channel, uint8_t flags) {
+		(void)channel;
+		(void)flags;
+	}
+
+	bool AudioHandler::is_playing(uint8_t channel) {
+		(void)channel;
+		return true; // Make splash wait for button press
+	}
+
+	void AudioHandler::update() {
+	}
+}

--- a/PicoAudio.hpp
+++ b/PicoAudio.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+
+namespace AudioHandler {
+	class AudioHandler {
+	public:
+		AudioHandler();
+
+		void set_volume(uint32_t = 0xffff);
+		void set_volume(uint8_t, uint32_t);
+
+		void load(uint8_t, const uint8_t[], const uint32_t);
+		void load(uint8_t, uint8_t);
+		void play(uint8_t, uint8_t = 0);
+		bool is_playing(uint8_t);
+		void update();
+	};
+}

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -861,64 +861,41 @@ protected:
 };
 ScreenShake shaker(SCREEN_SHAKE_SHAKINESS);
 
-class Colour {
-public:
-    uint8_t r, g, b, a;
-
-    Colour() {
-        r = g = b = a = 255;
-    }
-
-    Colour(uint8_t r, uint8_t g, uint8_t b) {
-        this->r = r;
-        this->g = g;
-        this->b = b;
-        a = 255;
-    }
-
-    Colour(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
-        this->r = r;
-        this->g = g;
-        this->b = b;
-        this->a = a;
-    }
-};
-
 // Particle colours
-const std::vector<Colour> playerDeathParticleColours[2] = {
-    { Colour(255, 255, 242), Colour(255, 204, 181), Colour(178, 53, 53) },
-    { Colour(255, 255, 242), Colour(178, 214, 96), Colour(37, 124, 73) }
+const std::vector<Pen> playerDeathParticleColours[2] = {
+    { Pen(255, 255, 242), Pen(255, 204, 181), Pen(178, 53, 53) },
+    { Pen(255, 255, 242), Pen(178, 214, 96), Pen(37, 124, 73) }
 };
-const std::vector<Colour> enemyDeathParticleColours[5] = {
-    { Colour(255, 255, 242), Colour(184, 197, 216), Colour(25, 40, 102) },
-    { Colour(255, 255, 242), Colour(255, 204, 181), Colour(165, 82, 139) },
-    { Colour(255, 255, 242), Colour(255, 204, 181), Colour(229, 114, 57) },
-    { Colour(255, 255, 242), Colour(204, 137, 124), Colour(127, 24, 75) },
-    { Colour(255, 255, 242), Colour(145, 224, 204), Colour(53, 130, 130) }
+const std::vector<Pen> enemyDeathParticleColours[5] = {
+    { Pen(255, 255, 242), Pen(184, 197, 216), Pen(25, 40, 102) },
+    { Pen(255, 255, 242), Pen(255, 204, 181), Pen(165, 82, 139) },
+    { Pen(255, 255, 242), Pen(255, 204, 181), Pen(229, 114, 57) },
+    { Pen(255, 255, 242), Pen(204, 137, 124), Pen(127, 24, 75) },
+    { Pen(255, 255, 242), Pen(145, 224, 204), Pen(53, 130, 130) }
 };
-const std::vector<Colour> bossDeathParticleColours[3] = {
-    { Colour(255, 255, 242), Colour(184, 197, 216), Colour(25, 40, 102) },
-    { Colour(255, 255, 242), Colour(255, 204, 181), Colour(165, 82, 139) },
-    { Colour(255, 255, 242), Colour(184, 197, 216), Colour(25, 40, 102) }
+const std::vector<Pen> bossDeathParticleColours[3] = {
+    { Pen(255, 255, 242), Pen(184, 197, 216), Pen(25, 40, 102) },
+    { Pen(255, 255, 242), Pen(255, 204, 181), Pen(165, 82, 139) },
+    { Pen(255, 255, 242), Pen(184, 197, 216), Pen(25, 40, 102) }
 };
-const std::vector<Colour> levelTriggerParticleColours = { Colour(255, 255, 242), Colour(145, 224, 204), Colour(53, 130, 130) };
+const std::vector<Pen> levelTriggerParticleColours = { Pen(255, 255, 242), Pen(145, 224, 204), Pen(53, 130, 130) };
 
-const std::vector<Colour> checkpointParticleColours[3] = {
-    { Colour(255, 255, 242), Colour(184, 197, 216) },
-    { Colour(178, 53, 53), Colour(127, 24, 75) },
-    { Colour(37, 124, 73), Colour(16, 84, 72) }
+const std::vector<Pen> checkpointParticleColours[3] = {
+    { Pen(255, 255, 242), Pen(184, 197, 216) },
+    { Pen(178, 53, 53), Pen(127, 24, 75) },
+    { Pen(37, 124, 73), Pen(16, 84, 72) }
 };
 
-const std::vector<Colour> finishParticleColours = { Colour(37, 124, 73), Colour(16, 84, 72), Colour(10, 57, 71) };
+const std::vector<Pen> finishParticleColours = { Pen(37, 124, 73), Pen(16, 84, 72), Pen(10, 57, 71) };
 
-const std::vector<Colour> slowPlayerParticleColours = { Colour(145, 224, 204), Colour(53, 130, 130) };//Colour(255, 255, 242), 
-const std::vector<Colour> repelPlayerParticleColours = { Colour(255, 235, 140), Colour(255, 199, 89) };
+const std::vector<Pen> slowPlayerParticleColours = { Pen(145, 224, 204), Pen(53, 130, 130) };//Pen(255, 255, 242), 
+const std::vector<Pen> repelPlayerParticleColours = { Pen(255, 235, 140), Pen(255, 199, 89) };
 
-const Colour inputSelectColour = Colour(255, 199, 89);
-const Colour hudBackground = Colour(7, 0, 14, 64);
-const Colour gameBackground = Colour(62, 106, 178);
-const Colour defaultWhite = Colour(255, 255, 242);
-Colour splashColour = Colour(7, 0, 14, 0);
+const Pen inputSelectColour = Pen(255, 199, 89);
+const Pen hudBackground = Pen(7, 0, 14, 64);
+const Pen gameBackground = Pen(62, 106, 178);
+const Pen defaultWhite = Pen(255, 255, 242);
+Pen splashColour = Pen(7, 0, 14, 0);
 
 class Camera {
 public:
@@ -992,7 +969,7 @@ public:
     float x, y;
     float xVel, yVel;
     float gravityX, gravityY;
-    Colour colour;
+    Pen colour;
     float age;
 
     Particle() {
@@ -1001,12 +978,12 @@ public:
 
         gravityX = 0;
         gravityY = 0;
-        colour = Colour(0, 0, 0);
+        colour = Pen(0, 0, 0);
 
         age = 0;
     }
 
-    Particle(float xPosition, float yPosition, float xVelocity, float yVelocity, float particleGravityX, float particleGravityY, Colour particleColour) {
+    Particle(float xPosition, float yPosition, float xVelocity, float yVelocity, float particleGravityX, float particleGravityY, Pen particleColour) {
         x = xPosition;
         y = yPosition;
         xVel = xVelocity;
@@ -1086,7 +1063,7 @@ public:
         speed = 0;
     }
 
-    BrownianParticle(float xPosition, float yPosition, uint16_t angle, float speed, float particleGravityX, float particleGravityY, Colour particleColour, uint8_t angleWiggle) : Particle(xPosition, yPosition, 0, 0, particleGravityX, particleGravityY, particleColour) {
+    BrownianParticle(float xPosition, float yPosition, uint16_t angle, float speed, float particleGravityX, float particleGravityY, Pen particleColour, uint8_t angleWiggle) : Particle(xPosition, yPosition, 0, 0, particleGravityX, particleGravityY, particleColour) {
         this->angleWiggle = angleWiggle;
         this->angle = angle;
         this->speed = speed;
@@ -1110,7 +1087,7 @@ protected:
 
 
 
-std::vector<Particle> generate_particles(float x, float y, float gravityX, float gravityY, std::vector<Colour> colours, float speed, uint8_t count) {
+std::vector<Particle> generate_particles(float x, float y, float gravityX, float gravityY, std::vector<Pen> colours, float speed, uint8_t count) {
     std::vector<Particle> particles;
 
     for (uint8_t i = 0; i < count; i++) {
@@ -1125,7 +1102,7 @@ std::vector<Particle> generate_particles(float x, float y, float gravityX, float
     return particles;
 }
 
-BrownianParticle generate_brownian_particle(float x, float y, float gravityX, float gravityY, float speed, std::vector<Colour> colours, uint8_t wiggle) {
+BrownianParticle generate_brownian_particle(float x, float y, float gravityX, float gravityY, float speed, std::vector<Pen> colours, uint8_t wiggle) {
     uint16_t angle = rand() % 360;
 
     return BrownianParticle(x, y, angle, speed, gravityX, gravityY, colours[rand() % colours.size()], wiggle);

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -14,7 +14,11 @@ using namespace blit;
 
 void init_game();
 
+#ifdef PICO_BUILD
+const uint16_t SCREEN_WIDTH = 120;
+#else
 const uint16_t SCREEN_WIDTH = 160;
+#endif
 const uint16_t SCREEN_HEIGHT = 120;
 
 const uint8_t LEVEL_COUNT = 10;
@@ -5591,6 +5595,7 @@ void load_audio() {
     // Set volume to a default
     audioHandler.set_volume(DEFAULT_VOLUME);
     // Sfx
+#ifndef PICO_BUILD
     audioHandler.load(0, asset_sound_select, asset_sound_select_length);
     audioHandler.load(1, asset_sound_jump, asset_sound_jump_length);
     audioHandler.load(2, asset_sound_coin, asset_sound_coin_length);
@@ -5600,6 +5605,7 @@ void load_audio() {
     audioHandler.load(6, asset_sound_enemythrow, asset_sound_enemythrow_length);
     // Music
     audioHandler.load(7, asset_music_splash, asset_music_splash_length);
+#endif
 
     // Start splash music playing
     audioHandler.play(7);

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -1762,6 +1762,7 @@ public:
                         y = foreground[i].y + SPRITE_SIZE;
                     }
                     yVel = 0;
+                    break;
                 }
             }
 
@@ -1785,6 +1786,7 @@ public:
                         x = foreground[i].x + SPRITE_SIZE - 1;
                     }
                     xVel = 0;
+                    break;
                 }
             }
 
@@ -3108,6 +3110,7 @@ public:
                         y = foreground[i].y + SPRITE_SIZE;
                     }
                     yVel = 0;
+                    break;
                 }
             }
 
@@ -3125,6 +3128,7 @@ public:
                             }
                             yVel = 0;
                         }
+                        break;
                     }
                 }
             }
@@ -3144,6 +3148,7 @@ public:
                         x = foreground[i].x + SPRITE_SIZE - 1;
                     }
                     xVel = 0;
+                    break;
                 }
             }
 

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -3964,12 +3964,6 @@ void render_finish() {
     finish.render(camera);
 }
 
-void render_background() {
-    screen.pen = gameBackground;
-
-    screen.clear();
-}
-
 void render_level() {
     render_parallax(parallax);
 
@@ -4534,8 +4528,6 @@ void render_sg_icon() {
 }
 
 void render_input_select() {
-    render_background();
-
     background_rect(0);
     background_rect(1);
 
@@ -4558,8 +4550,6 @@ void render_input_select() {
 }
 
 void render_character_select() {
-    render_background();
-
     render_level();
 
     render_entities();
@@ -4592,8 +4582,6 @@ void render_character_select() {
 }
 
 void render_menu() {
-    render_background();
-
     render_level();
 
     render_entities();
@@ -4626,8 +4614,6 @@ void render_menu() {
 }
 
 void render_settings() {
-    render_background();
-
     render_level();
 
     render_entities();
@@ -4685,8 +4671,6 @@ void render_settings() {
 }
 
 void render_level_select() {
-    render_background();
-
     render_level();
 
     render_entities();
@@ -4705,8 +4689,6 @@ void render_level_select() {
 }
 
 void render_game() {
-    render_background();
-
     render_level();
 
     if (bosses.size() == 0) {
@@ -4780,8 +4762,6 @@ void render_game() {
 
 
 void render_game_lost() {
-    render_background();
-
     render_level();
 
     if (bosses.size() == 0) {
@@ -4813,8 +4793,6 @@ void render_game_lost() {
 
 
 void render_game_won() {
-    render_background();
-
     render_level();
 
     if (bosses.size() == 0) {
@@ -5647,7 +5625,7 @@ void init() {
 //
 void render(uint32_t time) {
     // clear the screen -- screen is a reference to the frame buffer and can be used to draw all things with the 32blit
-    screen.pen = splashColour;
+    screen.pen = gameState == GameState::STATE_SG_ICON ? splashColour : gameBackground;
     screen.clear();
 
     // draw some text at the top of the screen

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -1955,6 +1955,11 @@ public:
 
     void update(float dt, ButtonStates buttonStates) {
         if (health > 0) {
+#ifdef PICO_BUILD
+            uint32_t dx = abs(*playerX - x);
+            if(dx > SCREEN_WIDTH) return; // TODO make this less hacky: Don't update enemies we can't see. Makes level ~7 playable on PicoSystem
+#endif
+
             if (reloadTimer) {
                 reloadTimer -= dt;
                 if (reloadTimer < 0) {

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -891,11 +891,11 @@ const std::vector<Pen> finishParticleColours = { Pen(37, 124, 73), Pen(16, 84, 7
 const std::vector<Pen> slowPlayerParticleColours = { Pen(145, 224, 204), Pen(53, 130, 130) };//Pen(255, 255, 242), 
 const std::vector<Pen> repelPlayerParticleColours = { Pen(255, 235, 140), Pen(255, 199, 89) };
 
-const Pen inputSelectColour = Pen(255, 199, 89);
-const Pen hudBackground = Pen(7, 0, 14, 64);
-const Pen gameBackground = Pen(62, 106, 178);
-const Pen defaultWhite = Pen(255, 255, 242);
-Pen splashColour = Pen(7, 0, 14, 0);
+const Pen inputSelectColour(255, 199, 89);
+const Pen hudBackground(7, 0, 14, 64);
+const Pen gameBackground(62, 106, 178);
+const Pen defaultWhite(255, 255, 242);
+Pen splashColour(7, 0, 14, 0);
 
 class Camera {
 public:
@@ -997,7 +997,7 @@ public:
     }
 
     void render(Camera camera) {
-        screen.pen = Pen(colour.r, colour.g, colour.b, colour.a);
+        screen.pen = colour;
         screen.pixel(Point(SCREEN_MID_WIDTH + x - camera.x, SCREEN_MID_HEIGHT + y - camera.y));
     }
 
@@ -1640,7 +1640,7 @@ public:
 
     void render(Camera camera) {
         if (visible) {
-            screen.pen = Pen(levelTriggerParticleColours[1].r, levelTriggerParticleColours[1].g, levelTriggerParticleColours[1].b, levelTriggerParticleColours[1].a);
+            screen.pen = levelTriggerParticleColours[1];
             screen.text(std::to_string(levelNumber + 1), minimal_font, Point(SCREEN_MID_WIDTH + x - camera.x + SPRITE_HALF, SCREEN_MID_HEIGHT + y - camera.y - SPRITE_HALF * 3 + textY), true, TextAlign::center_center);
             //screen.sprite(TILE_ID_LEVEL_TRIGGER, Point(SCREEN_MID_WIDTH + x - camera.x, SCREEN_MID_HEIGHT + y - camera.y));
             render_sprite(TILE_ID_LEVEL_TRIGGER, Point(SCREEN_MID_WIDTH + x - camera.x, SCREEN_MID_HEIGHT + y - camera.y));
@@ -3965,7 +3965,7 @@ void render_finish() {
 }
 
 void render_background() {
-    screen.pen = Pen(gameBackground.r, gameBackground.g, gameBackground.b);
+    screen.pen = gameBackground;
 
     screen.clear();
 }
@@ -4014,7 +4014,7 @@ void render_hud() {
     screen.rectangle(Rect(0, 0, SCREEN_WIDTH, SPRITE_HALF * 2 + 2));
 
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     // Player health
     for (uint8_t i = 0; i < PLAYER_MAX_HEALTH; i++) {
@@ -4048,13 +4048,13 @@ void render_nearby_level_info() {
             background_rect(1);
 
 
-            screen.pen = Pen(levelTriggerParticleColours[1].r, levelTriggerParticleColours[1].g, levelTriggerParticleColours[1].b);
+            screen.pen = levelTriggerParticleColours[1];
 
             // Level number
             screen.text("Level " + std::to_string(levelTriggers[i].levelNumber + 1), minimal_font, Point(SPRITE_HALF, SCREEN_HEIGHT - 9 - SPRITE_HALF), true, TextAlign::center_left);
 
 
-            screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+            screen.pen = defaultWhite;
 
             if (allPlayerSaveData[playerSelected].levelReached < levelTriggers[i].levelNumber) {
                 // Level is locked
@@ -4540,17 +4540,17 @@ void render_input_select() {
     background_rect(1);
 
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text("Select Input Method", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
-    screen.pen = gameSaveData.inputType == InputType::CONTROLLER ? Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b) : Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = gameSaveData.inputType == InputType::CONTROLLER ? inputSelectColour : defaultWhite;
     screen.text("Controller/32Blit", minimal_font, Point(SCREEN_MID_WIDTH, 50), true, TextAlign::center_center);
 
-    screen.pen = gameSaveData.inputType == InputType::KEYBOARD ? Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b) : Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = gameSaveData.inputType == InputType::KEYBOARD ? inputSelectColour : defaultWhite;
     screen.text("Keyboard", minimal_font, Point(SCREEN_MID_WIDTH, 70), true, TextAlign::center_center);
 
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     if (textFlashTimer < TEXT_FLASH_TIME * 0.6f) {
         screen.text(messageStrings[0][gameSaveData.inputType], minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
@@ -4580,10 +4580,10 @@ void render_character_select() {
     screen.pen = Pen(hudBackground.r, hudBackground.g, hudBackground.b, hudBackground.a);
     screen.rectangle(Rect(0, SCREEN_HEIGHT - (SPRITE_SIZE + 12 + 12), SCREEN_WIDTH, 12));
 
-    screen.pen = Pen(levelTriggerParticleColours[1].r, levelTriggerParticleColours[1].g, levelTriggerParticleColours[1].b);
+    screen.pen = levelTriggerParticleColours[1];
     screen.text("Player " + std::to_string(playerSelected + 1) + " (Save " + std::to_string(playerSelected + 1)  + ")", minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 10 - 12), true, TextAlign::center_center);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text("Select Player", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
     if (textFlashTimer < TEXT_FLASH_TIME * 0.6f) {
@@ -4602,23 +4602,23 @@ void render_menu() {
     background_rect(0);
     background_rect(1);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text("Super Square Bros.", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
     if (menuItem == 0) {
-        screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+        screen.pen = inputSelectColour;
     }
     screen.text("Play", minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_MID_HEIGHT - 10), true, TextAlign::center_center);
 
     if (menuItem == 0) {
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
     }
     else {
-        screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+        screen.pen = inputSelectColour;
     }
     screen.text("Settings", minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_MID_HEIGHT + 10), true, TextAlign::center_center);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     if (textFlashTimer < TEXT_FLASH_TIME * 0.6f) {
         screen.text(messageStrings[4][gameSaveData.inputType], minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
@@ -4642,7 +4642,7 @@ void render_settings() {
 
     background_rect(0);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text("Settings", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
     screen.text("Checkpoints:", minimal_font, Point(SPRITE_SIZE, SCREEN_MID_HEIGHT - SPRITE_SIZE * 3), true, TextAlign::center_left);
@@ -4651,23 +4651,23 @@ void render_settings() {
 
 
     if (settingsItem == 0) {
-        screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+        screen.pen = inputSelectColour;
     }
     screen.text(gameSaveData.checkpoints ? "On" : "Off", minimal_font, Point(SCREEN_WIDTH - SPRITE_SIZE * 2, SCREEN_MID_HEIGHT - SPRITE_SIZE * 3), true, TextAlign::center_right);
 
     if (settingsItem == 1) {
-        screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+        screen.pen = inputSelectColour;
     }
     else {
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
     }
     screen.text(gameSaveData.musicVolume ? "On" : "Off", minimal_font, Point(SCREEN_WIDTH - SPRITE_SIZE * 2, SCREEN_MID_HEIGHT - SPRITE_SIZE), true, TextAlign::center_right);
 
     if (settingsItem == 2) {
-        screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+        screen.pen = inputSelectColour;
     }
     else {
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
     }
     screen.text(gameSaveData.sfxVolume ? "On" : "Off", minimal_font, Point(SCREEN_WIDTH - SPRITE_SIZE * 2, SCREEN_MID_HEIGHT + SPRITE_SIZE), true, TextAlign::center_right);
 
@@ -4676,10 +4676,10 @@ void render_settings() {
     background_rect(1);
 
     /*if (textFlashTimer < TEXT_FLASH_TIME * 0.6f) {
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
         screen.text(messageStrings[4][gameSaveData.inputType], minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
     }*/
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text(messageStrings[5][gameSaveData.inputType], minimal_font, Point(SPRITE_SIZE * 2, SCREEN_HEIGHT - 9), true, TextAlign::center_left);
     screen.text(messageStrings[6][gameSaveData.inputType], minimal_font, Point(SCREEN_WIDTH - SPRITE_SIZE * 2, SCREEN_HEIGHT - 9), true, TextAlign::center_right);
 }
@@ -4698,7 +4698,7 @@ void render_level_select() {
 
     background_rect(0);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
     screen.text("Select level", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
     render_nearby_level_info();
@@ -4738,20 +4738,20 @@ void render_game() {
         //screen.pen = Pen(hudBackground.r, hudBackground.g, hudBackground.b, hudBackground.a);
         //screen.text(messageStrings[3][gameSaveData.inputType], minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
 
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
         display_stats(false);
         screen.text("Game Paused", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
         if (pauseMenuItem == 0) {
-            screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+            screen.pen = inputSelectColour;
         }
         screen.text("Resume", minimal_font, Point(SCREEN_MID_WIDTH - SPRITE_SIZE * 4, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
 
         if (pauseMenuItem == 1) {
-            screen.pen = Pen(inputSelectColour.r, inputSelectColour.g, inputSelectColour.b);
+            screen.pen = inputSelectColour;
         }
         else {
-            screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+            screen.pen = defaultWhite;
         }
         screen.text("Exit", minimal_font, Point(SCREEN_MID_WIDTH + SPRITE_SIZE * 4, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
 
@@ -4762,13 +4762,13 @@ void render_game() {
     else if (cameraIntro) {
         // Level <num> message
         background_rect(0);
-        screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+        screen.pen = defaultWhite;
         screen.text("Level " + std::to_string(currentLevelNumber + 1), minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
         // Press <key> to skip intro message
         background_rect(1);
         if (textFlashTimer < TEXT_FLASH_TIME * 0.6f) {
-            screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+            screen.pen = defaultWhite;
             screen.text(messageStrings[1][gameSaveData.inputType], minimal_font, Point(SCREEN_MID_WIDTH, SCREEN_HEIGHT - 9), true, TextAlign::center_center);
         }
     }
@@ -4800,7 +4800,7 @@ void render_game_lost() {
     background_rect(0);
     background_rect(1);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     screen.text("Level failed.", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
@@ -4833,7 +4833,7 @@ void render_game_won() {
     background_rect(0);
     background_rect(1);
 
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     screen.text("Level complete!", minimal_font, Point(SCREEN_MID_WIDTH, 10), true, TextAlign::center_center);
 
@@ -5647,13 +5647,13 @@ void init() {
 //
 void render(uint32_t time) {
     // clear the screen -- screen is a reference to the frame buffer and can be used to draw all things with the 32blit
-    screen.pen = Pen(splashColour.r, splashColour.g, splashColour.b);
+    screen.pen = splashColour;
     screen.clear();
 
     // draw some text at the top of the screen
     screen.alpha = 255;
     screen.mask = nullptr;
-    screen.pen = Pen(defaultWhite.r, defaultWhite.g, defaultWhite.b);
+    screen.pen = defaultWhite;
 
     if (gameState == GameState::STATE_SG_ICON) {
         render_sg_icon();
@@ -5686,7 +5686,7 @@ void render(uint32_t time) {
     render_transition();
 
     if (splashColour.a != 0) {
-        screen.pen = Pen(splashColour.r, splashColour.g, splashColour.b, splashColour.a);
+        screen.pen = splashColour;
         screen.clear();
     }
 }

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -562,7 +562,6 @@ float dt;
 uint32_t lastTime = 0;
 
 Surface* sg_icon_image = Surface::load(asset_scorpion_games);
-Surface* background_image = Surface::load(asset_background);
 
 AudioHandler::AudioHandler audioHandler;
 
@@ -3979,7 +3978,6 @@ void render_finish() {
 }
 
 void render_background() {
-    //screen.blit(background_image, Rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT), Point(0, 0), false);
     screen.pen = Pen(gameBackground.r, gameBackground.g, gameBackground.b);
 
     screen.clear();

--- a/SuperSquareBros.hpp
+++ b/SuperSquareBros.hpp
@@ -6,4 +6,8 @@
 #include "graphics/sprite.hpp"
 #include "graphics/color.hpp"
 
+#ifdef PICO_BUILD
+#include "PicoAudio.hpp"
+#else
 #include "Audio.hpp"
+#endif

--- a/assets.yml
+++ b/assets.yml
@@ -6,10 +6,10 @@ assets.cpp:
 
   assets/spritesheet.png:
     name: asset_sprites
-    
+
   assets/background.png:
     name: asset_background
-      
+
   assets/scorpion_games.png:
     name: asset_scorpion_games
 

--- a/assets.yml
+++ b/assets.yml
@@ -7,9 +7,6 @@ assets.cpp:
   assets/spritesheet.png:
     name: asset_sprites
 
-  assets/background.png:
-    name: asset_background
-
   assets/scorpion_games.png:
     name: asset_scorpion_games
 


### PR DESCRIPTION
Adds PicoSystem support in the least invasive way I could muster. PicoAudio is on standby for when PicoSystem can do something vaguely audio-like for bleeps and bloops.

* Basic setup for PicoSystem build and 120x120 screen resolution
* Stub out Audio for Pico using PicoAudio.cpp/hpp
* Exit some collision detection early for a significant speedup
* Remove remaining references to backgound_image and `clear()` to the background colour only once
* Crude speedhack for Pico - only update onscreen enemies - makes busier levels playable at the cost of consistency with other ports
* Remove "Colour" and use aligned "Pen" instead

This is a sometimes-different, sometimes-the-same take on @Daft-Freak's diff here - https://github.com/ThePythonator/Super-Square-Bros/compare/main...Daft-Freak:pico-maybe

I also have a patch to change all iterators to the form `for(auto &item : items)` if you want it.