### PR TITLE
PicoSystem: support for audio beep

### DIFF
--- a/Audio.cpp
+++ b/Audio.cpp
@@ -7,6 +7,8 @@ namespace AudioHandler {
 		
 	}
 
+	void AudioHandler::init() {}
+
 	void AudioHandler::set_volume(uint32_t volume) {
 		for (uint8_t i = 0; i < 8; i++) {
 			set_volume(i, volume);

--- a/Audio.hpp
+++ b/Audio.hpp
@@ -12,6 +12,8 @@ namespace AudioHandler {
 	public:
 		AudioHandler();
 
+		void init();
+
 		void set_volume(uint32_t = 0xffff);
 		void set_volume(uint8_t, uint32_t);
 		
@@ -22,9 +24,7 @@ namespace AudioHandler {
 		void update(float dt);
 
 	protected:
-#ifdef PICO_BUILD
-		float t = 0.0f;
-#else
+#ifndef PICO_BUILD
 		blit::MP3Stream mp3_channels[8];
 		const char* filenames[8] = {
 			"temp0.mp3", "temp1.mp3", "temp2.mp3", "temp3.mp3", "temp4.mp3", "temp5.mp3", "temp6.mp3", "temp7.mp3"

--- a/PicoAudio.cpp
+++ b/PicoAudio.cpp
@@ -2,63 +2,106 @@
 
 namespace AudioHandler {
 	AudioHandler::AudioHandler() {
+	}
+
+	void AudioHandler::init() {
+		// Coin A / Select
 		blit::channels[0].waveforms = blit::Waveform::SQUARE;
-		blit::channels[0].frequency = 1400;
-		blit::channels[0].attack_ms = 5;
+		blit::channels[0].frequency = 880;
+		blit::channels[0].attack_ms = 100;
 		blit::channels[0].decay_ms = 100;
 		blit::channels[0].sustain = 0;
-		blit::channels[0].release_ms = 5;
+		blit::channels[0].release_ms = 0;
+
+		// Jump
+		blit::channels[1].waveforms = blit::Waveform::SQUARE;
+		blit::channels[1].frequency = 440;
+		blit::channels[1].attack_ms = 150;
+		blit::channels[1].decay_ms = 1;
+		blit::channels[1].sustain = 0;
+		blit::channels[1].release_ms = 0;
+
+		// Coin B
+		blit::channels[2].waveforms = blit::Waveform::SQUARE;
+		blit::channels[2].frequency = 932;
+		blit::channels[2].attack_ms = 100;
+		blit::channels[2].decay_ms = 100;
+		blit::channels[2].sustain = 0;
+		blit::channels[2].release_ms = 0;
+
+		// Enemy Death
+		blit::channels[3].waveforms = blit::Waveform::SQUARE;
+		blit::channels[3].frequency = 300;
+		blit::channels[3].attack_ms = 100;
+		blit::channels[3].decay_ms = 100;
+		blit::channels[3].sustain = 0;
+		blit::channels[3].release_ms = 0;
+
+		// Enemy Injured
+		blit::channels[4].waveforms = blit::Waveform::SQUARE;
+		blit::channels[4].frequency = 300;
+		blit::channels[4].attack_ms = 100;
+		blit::channels[4].decay_ms = 100;
+		blit::channels[4].sustain = 0;
+		blit::channels[4].release_ms = 0;
+
+		// Player Death
+		blit::channels[5].waveforms = blit::Waveform::SQUARE;
+		blit::channels[5].frequency = 300;
+		blit::channels[5].attack_ms = 100;
+		blit::channels[5].decay_ms = 100;
+		blit::channels[5].sustain = 0;
+		blit::channels[5].release_ms = 0;
+
+		// Player Injured
+		blit::channels[6].waveforms = blit::Waveform::SQUARE;
+		blit::channels[6].frequency = 300;
+		blit::channels[6].attack_ms = 100;
+		blit::channels[6].decay_ms = 100;
+		blit::channels[6].sustain = 0;
+		blit::channels[6].release_ms = 0;
 	}
 
 	void AudioHandler::set_volume(uint32_t volume) {
-		for (uint8_t i = 0; i < 8; i++) {
-			set_volume(i, volume);
-		}
+		(void)volume;
 	}
 
 	void AudioHandler::set_volume(uint8_t channel, uint32_t volume) {
-		//blit::channels[channel].volume = volume;
+		(void)channel;
+		(void)volume;
 	}
 
 	void AudioHandler::load(uint8_t channel, const uint8_t mp3_data[], const uint32_t mp3_size) {
-		if (channel > 7) {
-			return;
-		}
-		/*blit::File::add_buffer_file(filenames[channel], mp3_data, mp3_size);
-		load(channel, channel);*/
+		(void)channel;
+		(void)mp3_data;
+		(void)mp3_size;
 	}
 
 	void AudioHandler::load(uint8_t target_channel, uint8_t source_channel) {
-		//mp3_channels[target_channel].load(filenames[source_channel]);
+		(void)target_channel;
+		(void)source_channel;
 	}
 
 	void AudioHandler::play(uint8_t channel, uint8_t flags) {
-		if (channel <= 2) {
-			blit::channels[0].trigger_attack();
-			t = 0.1;
+		if (channel <= 6) {
+			blit::channels[channel].trigger_attack();
 		}
-		/*mp3_channels[channel].pause();
-		mp3_channels[channel].restart();
-		mp3_channels[channel].play(channel, flags);*/
-
-		// TODO: make a boop sound instead
 	}
 
 	bool AudioHandler::is_playing(uint8_t channel) {
 		// Requires player to press A for splash screen to end
 		return true;
-		//return blit::channels[channel].adsr_phase != blit::ADSRPhase::OFF;
 	}
 
 	void AudioHandler::update(float dt) {
-		if (t > 0.0f) {
-			t -= dt;
-			if (t <= 0.0f) {
-				blit::channels[0].trigger_release();
-			}
-		}
-		/*for (uint8_t i = 0; i < 8; i++) {
-			mp3_channels[i].update();
-		}*/
+		blit::channels[1].frequency = 600 + (blit::channels[1].adsr >> 16);
+
+		blit::channels[0].frequency = blit::channels[0].adsr_phase == blit::ADSRPhase::ATTACK ? 880 : 1318;
+		blit::channels[2].frequency = blit::channels[2].adsr_phase == blit::ADSRPhase::ATTACK ? 932 : 1396;
+
+		blit::channels[3].frequency = 300 - (blit::channels[1].adsr >> 16);
+		blit::channels[4].frequency = 300 - (blit::channels[1].adsr >> 16);
+		blit::channels[5].frequency = 300 - (blit::channels[1].adsr >> 16);
+		blit::channels[6].frequency = 300 - (blit::channels[1].adsr >> 16);
 	}
 }

--- a/SuperSquareBros.cpp
+++ b/SuperSquareBros.cpp
@@ -5874,8 +5874,9 @@ void init_game() {
     }
 }
 
-#ifndef PICO_BUILD
 void load_audio() {
+    audioHandler.init();
+#ifndef PICO_BUILD
     // NOTE: CURRENTLY ISSUE WITH LEAVING PAUSE MENU, blip AUDIO IS PLAYED, BUT THEN NEW SOUND IS LOADED IN, STOPPING PLAYBACK.
 
     // Set volume to a default
@@ -5896,8 +5897,8 @@ void load_audio() {
 
     // Note: to play sfx0, call audioHandler.play(0)
     // For music, need to load sound when changing (i.e. audioHandler.load(7, asset_music_<music>, asset_music_<music>_length); audioHandler.play(7, 0b11);
-}
 #endif // PICO_BUILD
+}
 
 ///////////////////////////////////////////////////////////////////////////
 //
@@ -5936,9 +5937,7 @@ void init() {
     for (uint8_t i = 0; i < LEVEL_COUNT; i++) {
         allLevelSaveData[1][i] = load_level_data(1, i);
     }
-#ifndef PICO_BUILD
     load_audio();
-#endif // PICO_BUILD
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Uses 7 waveform channels to support Select/Coin, Jump, Coin, Enemy Death/Injured and Player Death/Injured SFX.

Uses the ADSR (Envelope Generator) state to control pitch.

Had to add an Audio.init() method, since configuring audio in the global constructor invokes undefined behaviour (and doesn't work).