### PR TITLE
Fix build for sprite.hpp removal

### DIFF
--- a/SuperSquareBros.hpp
+++ b/SuperSquareBros.hpp
@@ -3,7 +3,7 @@
 #include "engine/input.hpp"
 #include "engine/save.hpp"
 #include "engine/version.hpp"
-#include "graphics/sprite.hpp"
+#include "graphics/surface.hpp"
 #include "graphics/color.hpp"
 
 #include "Audio.hpp"


### PR DESCRIPTION
Just a tiny fix for a removed header (from when I was building random things for PicoVision).